### PR TITLE
plugin: allow custom mode names

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ let cursormode_color_map = {
       \ }
 ```
 
-The mode string are the ones returned by `:h mode()` and the colors are in the form of `#rrggbb`.
+The colors are in the form of `#rrggbb`.
+The mode string is the return value of the function stored in
+`g:cursormode_mode_func` (default is `:h mode()`).
 
 For example this is a possible map:
 
@@ -66,6 +68,33 @@ let cursormode_color_map = {
       \   "v":      "#00FF00",
       \   "V":      "#FF0000",
       \   "\<C-V>": "#FFFF00",
+      \ }
+```
+
+If you change the mode function, you can be more precise and do mappings like that:
+
+```viml
+function! cursormode_get_mode()
+    let l:mode = mode()
+    if l:mode ==# 'i' && (&readonly || ! &modifiable)
+        return 'i_readonly'
+    endif
+    if l:mode ==# 'i' && (&paste)
+        return 'i_paste'
+    endif
+    return l:mode
+endfunction
+
+let cursormode_mode_func = 'cursormode_get_mode'
+
+let cursormode_color_map = {
+      \   "n":          "#FFFFFF",
+      \   "i":          "#0000FF",
+      \   "i_paste":    "#00FFFF",
+      \   "i_readonly": "#FF00FF",
+      \   "v":          "#00FF00",
+      \   "V":          "#FF0000",
+      \   "\<C-V>":     "#FFFF00",
       \ }
 ```
 

--- a/plugin/cursormode.vim
+++ b/plugin/cursormode.vim
@@ -41,8 +41,12 @@ endfunction
 let s:iTerm_escape_template = '\033]Pl%s\033\\'
 let s:xterm_escape_template = '\033]12;%s\007'
 
+function! s:get_mode()
+  return call(get(g:, 'cursormode_mode_func', 'mode'), [])
+endfunction
+
 function! cursormode#CursorMode()
-  let mode = mode()
+  let mode = s:get_mode()
   if mode !=# s:last_mode
     let s:last_mode = mode
     call s:set_cursor_color_for(mode)


### PR DESCRIPTION
Hi!

Just dropping this here. I made a small enhancement to allow more precision in the mapping.

A new variable named cursormode_mode_func is used to store the function
returning the current mode. This allows more customization in the
mapping.
The default value is the built-in mode function so there is no change in
behavior.
Add example in README.